### PR TITLE
Fallback on env to collect credentials

### DIFF
--- a/wordle/python/wordle.py
+++ b/wordle/python/wordle.py
@@ -253,6 +253,26 @@ def play_botfights(bot, username, password, event):
             break
 
 
+def read_env(path):
+    with open(path) as f:
+        return dict(
+            line.strip().split("=", maxsplit=1)
+            for line in f.readlines()
+        )
+
+
+def collect_credentials():
+    user_key = "BOTFIGHTS_USER"
+    pass_key = "BOTFIGHTS_PASS"
+    try:
+        return os.environ[user_key], os.environ[pass_key]
+    except KeyError:
+        pass
+
+    environ = read_env(".env")
+    return environ[user_key], environ[pass_key]
+
+
 def main(argv):
     if 0 == len(argv):
         print(USAGE)
@@ -309,7 +329,11 @@ def main(argv):
         return x
     elif 'botfights' == c:
         bot = load_bot(argv[1])
-        username, password, event = argv[2:5]
+        try:
+            username, password, event = argv[2:5]
+        except ValueError:
+            username, password = collect_credentials()
+            event = argv[2]
         play_botfights(bot, username, password, event)
     elif 'api' == c:
         username = argv[1]


### PR DESCRIPTION
This allows the "botfights" command to be called without specifying
credentials. Benefits include
* no credentials in the shell history,
* convenient to not have to either find the last command in shell
  history or copy-paste credentials.